### PR TITLE
Fix for read_relaxed_coordinates_QE

### DIFF
--- a/src/file_io.py
+++ b/src/file_io.py
@@ -31,7 +31,7 @@ def struct_from_outputfile_QE ( fname:str ):
       celldm[3:] = [float(v) for i,v in enumerate(lines[eL+1].split()) if i%2==1]
 
       if ibrav != 0:
-        from lattice_format import lattice_format_QE
+        from .lattice_format import lattice_format_QE
         struct['lattice'] = lattice_format_QE(ibrav, celldm)
       else:
         while 'crystal axes' not in lines[eL]:
@@ -71,7 +71,7 @@ def read_relaxed_coordinates_QE ( fname:str, read_all:bool=True ):
     Returns:
       (dict): Dictionary with one or two entries - 'apos' for atomic positions and 'coord' for crystal coordinates.
   '''
-  from conversion import ANG_BOHR
+  from .conversion import ANG_BOHR
   from os.path import isfile,join
   from os import getcwd
   import numpy as np
@@ -253,7 +253,7 @@ def struct_from_inputfile_QE ( fname:str ) -> dict:
     Returns:
       (dict): Structure dictionary
   '''
-  from conversion import ANG_BOHR
+  from .conversion import ANG_BOHR
   from os.path import isfile
   import numpy as np
   import re
@@ -397,7 +397,7 @@ def struct_from_inputfile_QE ( fname:str ) -> dict:
     struct['lattice'] = np.array([np.array([float(v) for v in fstr[cl+c].split()]) for c in range(3)])
 
   if 'lattice' not in struct:
-    from lattice_format import lattice_format_QE
+    from .lattice_format import lattice_format_QE
     struct['lattice'] = lattice_format_QE(struct['ibrav'], struct['celldm'])
 
   if struct['lunit'] == 'angstrom':
@@ -420,7 +420,7 @@ def struct_from_inputfile_QE ( fname:str ) -> dict:
 
 
 def struct_from_atoms_ASE ( atoms ):
-  from conversion import ANG_BOHR
+  from .conversion import ANG_BOHR
   import numpy as np
 
   syms = atoms.symbols

--- a/src/file_io.py
+++ b/src/file_io.py
@@ -31,7 +31,7 @@ def struct_from_outputfile_QE ( fname:str ):
       celldm[3:] = [float(v) for i,v in enumerate(lines[eL+1].split()) if i%2==1]
 
       if ibrav != 0:
-        from .lattice_format import lattice_format_QE
+        from lattice_format import lattice_format_QE
         struct['lattice'] = lattice_format_QE(ibrav, celldm)
       else:
         while 'crystal axes' not in lines[eL]:
@@ -60,7 +60,7 @@ def struct_from_outputfile_QE ( fname:str ):
   return struct
 
 
-def read_relaxed_coordinates_QE ( fname:str ):
+def read_relaxed_coordinates_QE ( fname:str, vcrelax:bool=True, read_all:bool=True ):
   '''
     Reads relaxed atomic positions from a QE .out file. If CELL_PARAMETERS is present, the crystal coordinates are also read.
 
@@ -72,7 +72,7 @@ def read_relaxed_coordinates_QE ( fname:str ):
     Returns:
       (dict): Dictionary with one or two entries - 'apos' for atomic positions and 'coord' for crystal coordinates.
   '''
-  from .conversion import ANG_BOHR
+  from conversion import ANG_BOHR
   from os.path import isfile,join
   from os import getcwd
   import numpy as np
@@ -143,6 +143,12 @@ def read_relaxed_coordinates_QE ( fname:str ):
     except Exception as e:
       print('WARNING: No atomic positions or cell coordinates were found.', flush=True)
       raise e
+
+  if not read_all:
+    # Keep only last set of coords
+    abc = abc[-1]
+  elif ( not read_all ) and vcrelax:
+    cell_params = cell_params[-1]
 
   struct['lunit'] = 'bohr'
   struct['aunit'] = 'crystal'
@@ -242,7 +248,7 @@ def struct_from_inputfile_QE ( fname:str ) -> dict:
     Returns:
       (dict): Structure dictionary
   '''
-  from .conversion import ANG_BOHR
+  from conversion import ANG_BOHR
   from os.path import isfile
   import numpy as np
   import re
@@ -386,7 +392,7 @@ def struct_from_inputfile_QE ( fname:str ) -> dict:
     struct['lattice'] = np.array([np.array([float(v) for v in fstr[cl+c].split()]) for c in range(3)])
 
   if 'lattice' not in struct:
-    from .lattice_format import lattice_format_QE
+    from lattice_format import lattice_format_QE
     struct['lattice'] = lattice_format_QE(struct['ibrav'], struct['celldm'])
 
   if struct['lunit'] == 'angstrom':
@@ -409,7 +415,7 @@ def struct_from_inputfile_QE ( fname:str ) -> dict:
 
 
 def struct_from_atoms_ASE ( atoms ):
-  from .conversion import ANG_BOHR
+  from conversion import ANG_BOHR
   import numpy as np
 
   syms = atoms.symbols

--- a/src/file_io.py
+++ b/src/file_io.py
@@ -60,13 +60,12 @@ def struct_from_outputfile_QE ( fname:str ):
   return struct
 
 
-def read_relaxed_coordinates_QE ( fname:str, vcrelax:bool=True, read_all:bool=True ):
+def read_relaxed_coordinates_QE ( fname:str, read_all:bool=True ):
   '''
     Reads relaxed atomic positions from a QE .out file. If CELL_PARAMETERS is present, the crystal coordinates are also read.
 
     Arguments:
       fname (str): File name (including path) for the .out file
-      vcrelax (bool): True reads crystal coordinates in addition to atomic positions
       read_all (bool): True forces all relax steps to be read. If EoF is encountered before 'final coordinates' the last coordinates to appear in the file are retunred. If no coordinates are found, an empty dictionary is returned.
 
     Returns:
@@ -117,10 +116,9 @@ def read_relaxed_coordinates_QE ( fname:str, vcrelax:bool=True, read_all:bool=Tr
           abc.append(apos)
           eL = sind
 
-        elif 'CELL_PARAMETERS' in lines[eL]:
+        elif ('CELL_PARAMETERS' in lines[eL]):
           coord = []
           unit = lines[eL].split()[1].strip('(){{}}')
-
           alat = 1
           if 'alat' in unit or len(unit) == 0:
             struct['lunit'] = 'alat'
@@ -144,16 +142,23 @@ def read_relaxed_coordinates_QE ( fname:str, vcrelax:bool=True, read_all:bool=Tr
       print('WARNING: No atomic positions or cell coordinates were found.', flush=True)
       raise e
 
-  if not read_all:
-    # Keep only last set of coords
+  # If it's a vc-relax keep only the last vectors+positions
+  # If it's a relax, keep only the last positions, cell vectors from header
+  # else, pass the initial + full relaxation trajectory
+  if len(cell_params)>0 and ( not read_all ):
+    cell_params = np.array(cell_params[-1])
     abc = abc[-1]
-  elif ( not read_all ) and vcrelax:
-    cell_params = cell_params[-1]
+  elif ( not read_all ):
+    cell_params = struct['lattice']
+    abc = abc[-1]
+  else:
+    cell_params = np.array([struct['lattice']] + cell_params)
+    abc = np.array([struct['abc']] + abc)
 
   struct['lunit'] = 'bohr'
   struct['aunit'] = 'crystal'
-  struct['lattice'] = np.array([struct['lattice']] + cell_params)
-  struct['abc'] = np.array([struct['abc']] + abc)
+  struct['lattice'] = cell_params
+  struct['abc'] = abc
 
   return struct
 


### PR DESCRIPTION
Closes #19 

changes in src/file_io.py
routine read_relaxed_coordinates_QE
primarily around line 150

The function currently does not accept the keywords described in the docstring, and attempts to detect whether the log is vc-relax or relax. The user cannot choose whether to skip the full trajectory.

The only difference between relax/vc-relax to the function is in the length of returned cell_parameters and atomic positions. Using these, read_all now will optionally ignore the full relax trajectory and return the final cell_parameters + coordinates if requested.

There is no option to ignore output cell_parameters, because it seems like it'd only encourage errors like if you forget to set a flag acknowledging it's a vc-relax, then assume your final relaxed coordinates are in the initial cell when they are not.